### PR TITLE
#3 Configure persistence to use mysql and provide docker compose for …

### DIFF
--- a/acropolis-persistence/build.gradle
+++ b/acropolis-persistence/build.gradle
@@ -36,8 +36,6 @@ dependencies {
     // Needed for spring to work with Kotlin
     compile "org.jetbrains.kotlin:kotlin-reflect"
 
-    runtime group: 'com.h2database', name: 'h2', version: '1.4.197'
-
     // https://mvnrepository.com/artifact/javax.xml.bind/jaxb-api
     compile group: 'javax.xml.bind', name: 'jaxb-api', version: '2.3.0'
 }

--- a/acropolis-persistence/src/main/resources/application.yml
+++ b/acropolis-persistence/src/main/resources/application.yml
@@ -1,7 +1,11 @@
 spring:
   jpa:
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: update
+  datasource:
+    url: 'jdbc:mysql://localhost:3306/acropolisdev'
+    username: root
+    password: root
   h2:
     console:
       enabled: true

--- a/env/docker-compose.yml
+++ b/env/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '3.7'
 services:
   acropolis-mysql:
     image: 'mysql:8'

--- a/env/docker-compose.yml
+++ b/env/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3'
+services:
+  acropolis-mysql:
+    image: 'mysql:8'
+    environment:
+      - MYSQL_ROOT_PASSWORD=root
+      - MYSQL_PASSWORD=root
+      - MYSQL_DATABASE=acropolisdev
+    ports:
+      - 3306:3306


### PR DESCRIPTION
The persistence layer has been configured to use mysql and there's now a docker compose file to host the database.
Also tidied up the H2 which we're not using any more