### PR TITLE
Feature/30 Code Quality fixes

### DIFF
--- a/acropolis-persistence/src/main/kotlin/org/ephyra/acropolis/persistence/api/entity/LoadBalancerEntity.kt
+++ b/acropolis-persistence/src/main/kotlin/org/ephyra/acropolis/persistence/api/entity/LoadBalancerEntity.kt
@@ -1,11 +1,7 @@
 package org.ephyra.acropolis.persistence.api.entity
 
 import org.ephyra.acropolis.persistence.api.ConnectionType
-import org.ephyra.acropolis.persistence.api.IConnectable
 import javax.persistence.Entity
-import javax.persistence.GeneratedValue
-import javax.persistence.GenerationType
-import javax.persistence.Id
 
 @Entity
 class LoadBalancerEntity @JvmOverloads constructor (

--- a/acropolis-persistence/src/main/kotlin/org/ephyra/acropolis/persistence/api/entity/ProjectEntity.kt
+++ b/acropolis-persistence/src/main/kotlin/org/ephyra/acropolis/persistence/api/entity/ProjectEntity.kt
@@ -9,7 +9,7 @@ import javax.persistence.Id
 class ProjectEntity {
     @Id
     @GeneratedValue(strategy= GenerationType.AUTO)
-    var id: Int = 0
+    var id: Long = 0
 
     var name: String = ""
 }

--- a/acropolis-persistence/src/main/kotlin/org/ephyra/acropolis/persistence/api/entity/ReverseProxyEntity.kt
+++ b/acropolis-persistence/src/main/kotlin/org/ephyra/acropolis/persistence/api/entity/ReverseProxyEntity.kt
@@ -1,8 +1,7 @@
 package org.ephyra.acropolis.persistence.api.entity
 
 import org.ephyra.acropolis.persistence.api.ConnectionType
-import org.ephyra.acropolis.persistence.api.IConnectable
-import javax.persistence.*
+import javax.persistence.Entity
 
 @Entity
 class ReverseProxyEntity @JvmOverloads constructor (

--- a/acropolis-persistence/src/main/kotlin/org/ephyra/acropolis/persistence/api/persistence/ApplicationSoftwarePersistence.kt
+++ b/acropolis-persistence/src/main/kotlin/org/ephyra/acropolis/persistence/api/persistence/ApplicationSoftwarePersistence.kt
@@ -4,7 +4,6 @@ import org.ephyra.acropolis.persistence.api.entity.ApplicationSoftwareEntity
 import org.ephyra.acropolis.persistence.impl.ApplicationSoftwareRepository
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
-import java.util.*
 
 @Component
 class ApplicationSoftwarePersistence {

--- a/acropolis-persistence/src/main/kotlin/org/ephyra/acropolis/persistence/api/persistence/ProjectPersistence.kt
+++ b/acropolis-persistence/src/main/kotlin/org/ephyra/acropolis/persistence/api/persistence/ProjectPersistence.kt
@@ -18,11 +18,17 @@ class ProjectPersistence {
         repo.deleteById(id)
     }
 
-    fun getProjects(): List<ProjectEntity> {
+    fun getAll(): List<ProjectEntity> {
         return repo.findAll().toList()
     }
 
-    fun getProject(name: String): ProjectEntity {
-        return repo.findByName(name)
+    fun find(id: Long): ProjectEntity? {
+        val entity = repo.findById(id)
+        return if (entity.isPresent) entity.get() else null
+    }
+
+    fun findByName(name: String): ProjectEntity? {
+        val entity = repo.findByName(name)
+        return if (entity.isPresent) entity.get() else null
     }
 }

--- a/acropolis-persistence/src/main/kotlin/org/ephyra/acropolis/persistence/api/persistence/QueuePersistence.kt
+++ b/acropolis-persistence/src/main/kotlin/org/ephyra/acropolis/persistence/api/persistence/QueuePersistence.kt
@@ -14,7 +14,7 @@ class QueuePersistence {
         repo.save(queue)
     }
 
-    fun getQueues(): List<QueueEntity> {
+    fun getAll(): List<QueueEntity> {
         return repo.findAll().toList()
     }
 }

--- a/acropolis-persistence/src/main/kotlin/org/ephyra/acropolis/persistence/impl/ProjectRepository.kt
+++ b/acropolis-persistence/src/main/kotlin/org/ephyra/acropolis/persistence/impl/ProjectRepository.kt
@@ -2,7 +2,8 @@ package org.ephyra.acropolis.persistence.impl
 
 import org.ephyra.acropolis.persistence.api.entity.ProjectEntity
 import org.springframework.data.repository.CrudRepository
+import java.util.*
 
 internal interface ProjectRepository : CrudRepository<ProjectEntity, Long> {
-    fun findByName(name: String): ProjectEntity
+    fun findByName(name: String): Optional<ProjectEntity>
 }

--- a/acropolis-rest/src/main/kotlin/org/ephyra/acropolis/rest/ProjectController.kt
+++ b/acropolis-rest/src/main/kotlin/org/ephyra/acropolis/rest/ProjectController.kt
@@ -16,17 +16,17 @@ class ProjectController {
     @RequestMapping(value = ["/projects"], method = [(RequestMethod.POST)])
     @ResponseStatus(value = HttpStatus.OK)
     fun createProject(@RequestParam(value="name", defaultValue="World") name: String) {
-        service.createProject(name)
+        service.create(name)
     }
 
     @RequestMapping(value = ["/project/{id}"], method = [(RequestMethod.DELETE)])
     fun deleteProject(@PathVariable("id") id: Long) {
-        service.deleteProject(id)
+        service.delete(id)
     }
 
     @RequestMapping(value = ["/projects"], method = [(RequestMethod.GET)])
     fun getProjects(): List<ProjectEntity> {
-        return service.listProjects()
+        return service.list()
     }
 
 }

--- a/acropolis-service/src/main/kotlin/org/ephyra/acropolis/service/api/IApplicationSoftwareService.kt
+++ b/acropolis-service/src/main/kotlin/org/ephyra/acropolis/service/api/IApplicationSoftwareService.kt
@@ -1,5 +1,5 @@
 package org.ephyra.acropolis.service.api
 
 interface IApplicationSoftwareService {
-    fun create(projectId: Int, name: String)
+    fun create(projectId : Long, name: String)
 }

--- a/acropolis-service/src/main/kotlin/org/ephyra/acropolis/service/api/IDatastoreService.kt
+++ b/acropolis-service/src/main/kotlin/org/ephyra/acropolis/service/api/IDatastoreService.kt
@@ -3,6 +3,6 @@ package org.ephyra.acropolis.service.api
 import org.ephyra.acropolis.persistence.api.entity.DatastoreEntity
 
 interface IDatastoreService {
-    fun create(projectId: Int, name: String)
+    fun create(projectId: Long, name: String)
     fun get(name: String): DatastoreEntity?
 } 

--- a/acropolis-service/src/main/kotlin/org/ephyra/acropolis/service/api/IProjectService.kt
+++ b/acropolis-service/src/main/kotlin/org/ephyra/acropolis/service/api/IProjectService.kt
@@ -3,8 +3,8 @@ package org.ephyra.acropolis.service.api
 import org.ephyra.acropolis.persistence.api.entity.ProjectEntity
 
 interface IProjectService {
-    fun createProject(name: String)
-    fun deleteProject(id: Long)
-    fun listProjects(): List<ProjectEntity>
-    fun getProject(name: String): ProjectEntity
+    fun create(name: String)
+    fun delete(id: Long)
+    fun list(): List<ProjectEntity>
+    fun get(name: String): ProjectEntity?
 }

--- a/acropolis-service/src/main/kotlin/org/ephyra/acropolis/service/api/ISystemSoftwareService.kt
+++ b/acropolis-service/src/main/kotlin/org/ephyra/acropolis/service/api/ISystemSoftwareService.kt
@@ -3,7 +3,7 @@ package org.ephyra.acropolis.service.api
 import org.ephyra.acropolis.persistence.api.entity.SystemSoftwareEntity
 
 interface ISystemSoftwareService {
-    fun create(projectId: Int, name: String)
+    fun create(projectId : Long, name: String)
 
     fun get(name: String): SystemSoftwareEntity?
 }

--- a/acropolis-service/src/main/kotlin/org/ephyra/acropolis/service/impl/ApplicationSoftwareService.kt
+++ b/acropolis-service/src/main/kotlin/org/ephyra/acropolis/service/impl/ApplicationSoftwareService.kt
@@ -1,8 +1,8 @@
 package org.ephyra.acropolis.service.impl
 
-import org.ephyra.acropolis.persistence.api.persistence.ApplicationSoftwarePersistence
 import org.ephyra.acropolis.persistence.api.entity.ApplicationSoftwareEntity
 import org.ephyra.acropolis.persistence.api.entity.ProjectEntity
+import org.ephyra.acropolis.persistence.api.persistence.ApplicationSoftwarePersistence
 import org.ephyra.acropolis.service.api.IApplicationSoftwareService
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component

--- a/acropolis-service/src/main/kotlin/org/ephyra/acropolis/service/impl/ApplicationSoftwareService.kt
+++ b/acropolis-service/src/main/kotlin/org/ephyra/acropolis/service/impl/ApplicationSoftwareService.kt
@@ -12,7 +12,7 @@ class ApplicationSoftwareService : IApplicationSoftwareService {
     @Autowired
     private lateinit var persistence: ApplicationSoftwarePersistence
 
-    override fun create(projectId: Int, name: String) {
+    override fun create(projectId : Long, name: String) {
         val project = ProjectEntity()
         project.id = projectId
 

--- a/acropolis-service/src/main/kotlin/org/ephyra/acropolis/service/impl/DatastoreService.kt
+++ b/acropolis-service/src/main/kotlin/org/ephyra/acropolis/service/impl/DatastoreService.kt
@@ -1,8 +1,8 @@
 package org.ephyra.acropolis.service.impl
 
-import org.ephyra.acropolis.persistence.api.persistence.DatastorePersistence
 import org.ephyra.acropolis.persistence.api.entity.DatastoreEntity
 import org.ephyra.acropolis.persistence.api.entity.ProjectEntity
+import org.ephyra.acropolis.persistence.api.persistence.DatastorePersistence
 import org.ephyra.acropolis.service.api.IDatastoreService
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component

--- a/acropolis-service/src/main/kotlin/org/ephyra/acropolis/service/impl/DatastoreService.kt
+++ b/acropolis-service/src/main/kotlin/org/ephyra/acropolis/service/impl/DatastoreService.kt
@@ -13,7 +13,7 @@ class DatastoreService : IDatastoreService {
     @Autowired
     private lateinit var persistence: DatastorePersistence
 
-    override fun create(projectId: Int, name: String) {
+    override fun create(projectId : Long, name: String) {
         val project = ProjectEntity()
         project.id = projectId
 

--- a/acropolis-service/src/main/kotlin/org/ephyra/acropolis/service/impl/LoadBalancerService.kt
+++ b/acropolis-service/src/main/kotlin/org/ephyra/acropolis/service/impl/LoadBalancerService.kt
@@ -1,7 +1,6 @@
 package org.ephyra.acropolis.service.impl
 
 import org.ephyra.acropolis.persistence.api.entity.LoadBalancerEntity
-import org.ephyra.acropolis.persistence.api.entity.ReverseProxyEntity
 import org.ephyra.acropolis.persistence.api.persistence.LoadBalancerPersistence
 import org.ephyra.acropolis.persistence.api.persistence.SystemSoftwarePersistence
 import org.ephyra.acropolis.service.api.ILoadBalancerService

--- a/acropolis-service/src/main/kotlin/org/ephyra/acropolis/service/impl/ProjectService.kt
+++ b/acropolis-service/src/main/kotlin/org/ephyra/acropolis/service/impl/ProjectService.kt
@@ -11,23 +11,23 @@ class ProjectService : IProjectService {
     @Autowired
     private lateinit var persistence: ProjectPersistence
 
-    override fun createProject(name: String) {
+    override fun create(name: String) {
         println("Acropolis service is creating project with name $name")
         val project = ProjectEntity()
         project.name = name
         persistence.create(project)
     }
 
-    override fun deleteProject(id: Long) {
+    override fun delete(id: Long) {
         println("Acropolis service is deleting project #$id")
         persistence.delete(id)
     }
 
-    override fun listProjects(): List<ProjectEntity> {
-        return persistence.getProjects()
+    override fun list(): List<ProjectEntity> {
+        return persistence.getAll()
     }
 
-    override fun getProject(name: String): ProjectEntity {
-        return persistence.getProject(name)
+    override fun get(name: String): ProjectEntity? {
+        return persistence.findByName(name)
     }
 }

--- a/acropolis-service/src/main/kotlin/org/ephyra/acropolis/service/impl/SystemSoftwareService.kt
+++ b/acropolis-service/src/main/kotlin/org/ephyra/acropolis/service/impl/SystemSoftwareService.kt
@@ -12,7 +12,7 @@ class SystemSoftwareService : ISystemSoftwareService {
     @Autowired
     private lateinit var persistence: SystemSoftwarePersistence
 
-    override fun create(projectId: Int, name: String) {
+    override fun create(projectId : Long, name: String) {
         val project = ProjectEntity()
         project.id = projectId
 

--- a/acropolis-shell/src/main/kotlin/org/ephyra/acropolis/shell/Application.kt
+++ b/acropolis-shell/src/main/kotlin/org/ephyra/acropolis/shell/Application.kt
@@ -1,10 +1,8 @@
 package org.ephyra.acropolis.shell
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
-import org.springframework.boot.autoconfigure.domain.EntityScan
 import org.springframework.boot.runApplication
 import org.springframework.context.annotation.ComponentScan
-import org.springframework.data.jpa.repository.config.EnableJpaRepositories
 
 @SpringBootApplication
 @ComponentScan(basePackages = ["org.ephyra.acropolis.shell", "org.ephyra.acropolis.service.config"])

--- a/acropolis-shell/src/main/kotlin/org/ephyra/acropolis/shell/CreateCommand.kt
+++ b/acropolis-shell/src/main/kotlin/org/ephyra/acropolis/shell/CreateCommand.kt
@@ -67,6 +67,6 @@ class CreateCommand {
     }
 
     private fun createProject(name: String) {
-        projectService.createProject(name)
+        projectService.create(name)
     }
 }

--- a/acropolis-shell/src/main/kotlin/org/ephyra/acropolis/shell/ListCommand.kt
+++ b/acropolis-shell/src/main/kotlin/org/ephyra/acropolis/shell/ListCommand.kt
@@ -6,7 +6,6 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.shell.standard.ShellComponent
 import org.springframework.shell.standard.ShellMethod
 import org.springframework.shell.standard.ShellOption
-import java.util.function.Consumer
 
 @ShellComponent
 class ListCommand {

--- a/acropolis-shell/src/main/kotlin/org/ephyra/acropolis/shell/ListCommand.kt
+++ b/acropolis-shell/src/main/kotlin/org/ephyra/acropolis/shell/ListCommand.kt
@@ -29,7 +29,7 @@ class ListCommand {
     }
 
     private fun listProjects() {
-        val result = projectService.listProjects()
+        val result = projectService.list()
         for (r in result) {
             println(r.name)
         }

--- a/acropolis-shell/src/main/kotlin/org/ephyra/acropolis/shell/SelectCommand.kt
+++ b/acropolis-shell/src/main/kotlin/org/ephyra/acropolis/shell/SelectCommand.kt
@@ -21,6 +21,6 @@ class SelectCommand {
     }
 
     private fun selectProject(name: String) {
-        appState.currentProject = projectService.getProject(name)
+        appState.currentProject = projectService.get(name)
     }
 }

--- a/acropolis-shell/src/main/kotlin/org/ephyra/acropolis/shell/ShellPrompt.kt
+++ b/acropolis-shell/src/main/kotlin/org/ephyra/acropolis/shell/ShellPrompt.kt
@@ -1,9 +1,9 @@
 package org.ephyra.acropolis.shell
 
 import org.jline.utils.AttributedString
+import org.jline.utils.AttributedStyle
 import org.springframework.shell.jline.PromptProvider
 import org.springframework.stereotype.Component
-import org.jline.utils.AttributedStyle
 
 @Component
 class ShellPrompt : PromptProvider {


### PR DESCRIPTION
Closes #30 

Bunch of nicities. We already know that we're listing projects because we're using a ProjectService, reduce method name to `list`, in line with the way newer entites have been done. `getAll()` instead of `getProjects()`, etc.
